### PR TITLE
fix the bug of unerwartete Anzeige der PWAInstallButton (Ursache: Fehlen of event appinstalled)_HDN_40

### DIFF
--- a/src/components/PwaInstallation.tsx
+++ b/src/components/PwaInstallation.tsx
@@ -37,10 +37,16 @@ const PwaInstallation = () => {
       }
     }
 
+    const handleAfterInstallPrompt = () => {
+      setShowInstallButton(false);
+    }
+
     window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt)
+    window.addEventListener('appinstalled', handleAfterInstallPrompt)
 
     return () => {
       window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt)
+      window.removeEventListener('appinstalled', handleAfterInstallPrompt)
     }
   }, [hasChrome, hasSafari, isPWA])
 


### PR DESCRIPTION
HDN-40

**Der Bug, auf den dieser PR fokussiert, geht darum, dass der InstallButton immer noch direkt nach der erfolgreichen Installation von PWA in PWA steht**

Die Lösung kommt aus das Posten von Stackoverflow:

Quelle:
https://stackoverflow.com/questions/55654675/add-to-home-screen-is-prompt-coming-even-after-pwa-app-installed

**Vor dieser PR:**

https://github.com/user-attachments/assets/ae78a29f-d401-4731-afa9-013b05db7edf

**Nach dieser PR:**

https://github.com/user-attachments/assets/5fc0ecd7-1da9-4e86-9ee7-fbeb13f62e1f

