### PR TITLE
fix: close menu tracking

### DIFF
--- a/src/components/AppBarWithMenu.tsx
+++ b/src/components/AppBarWithMenu.tsx
@@ -113,7 +113,12 @@ const AppBarWithMenu = () => {
             </Toolbar>
           </Grid>
           <Grid>
-            <MainMenu onMenuItemClick={closeMenu} />
+            <MainMenu
+              // does not use onClose because we do not want trackEvent here
+              onMenuItemClick={() => {
+                setMenuOpen(false)
+              }}
+            />
           </Grid>
         </Grid>
         <PwaInstallation />


### PR DESCRIPTION
keine Ahnung, warum es anders herum nicht richtig funktioniert hat, aber es war eh nicht einheitlich mit openMenu