### PR TITLE
fix: missing slash in absolute image src

### DIFF
--- a/src/components/AppBarWithMenu.tsx
+++ b/src/components/AppBarWithMenu.tsx
@@ -57,7 +57,7 @@ const AppBarWithMenu = () => {
           </Grid>
           <Grid size='grow' display='flex' alignItems='center'>
             <Image
-              src='appgefahren.svg'
+              src='/appgefahren.svg'
               alt={'appgefahren'}
               height={36}
               width={1} // It is neccessary but no effect


### PR DESCRIPTION
Bild konnte sonst nicht auf Datenschutzseite geladen werden 
<img width="498" height="239" alt="Bildschirmfoto 2025-07-24 um 14 48 23" src="https://github.com/user-attachments/assets/42dc2f35-4e21-4af7-a745-1564128e7c88" />
