### PR TITLE
Feature/hdn 118 track pwa installation

### DIFF
--- a/src/components/Matomo/constants.ts
+++ b/src/components/Matomo/constants.ts
@@ -1,3 +1,4 @@
 export enum CustomDimensions {
   ENVIRONMENT = 1,
+  IS_PWA = 9,
 }

--- a/src/components/Matomo/useMatomo.ts
+++ b/src/components/Matomo/useMatomo.ts
@@ -8,7 +8,7 @@ const useMatomo = () => {
   // XXX poc matomo tracking
   // eslint-disable-next-line
   const push = (args: any[]) => {
-    // @ts-expect-error prevent unknown property errore
+    // @ts-expect-error prevent unknown property error
     // eslint-disable-next-line
     const _paq: any = (window._paq = window._paq || [])
     _paq.push(args)
@@ -38,6 +38,14 @@ const useMatomo = () => {
     push(['trackSiteSearch', search, category, numberOfResults])
   }
 
+  const setCustomDimension = (
+    customDimensionId: number,
+    customDimensionValue: string | number
+  ) => {
+    push(['setCustomDimension', customDimensionId, customDimensionValue])
+    push(['trackPageView'])
+  }
+
   // this is a debounced version of the standard trackSiteSearch call
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const debouncedTrackSiteSearch = useCallback(
@@ -53,6 +61,7 @@ const useMatomo = () => {
 
   return {
     push,
+    setCustomDimension,
     trackPageView,
     trackEvent,
     trackSiteSearch,

--- a/src/components/PwaInstallation.tsx
+++ b/src/components/PwaInstallation.tsx
@@ -50,6 +50,7 @@ const PwaInstallation = () => {
     }
 
     const handleAfterInstallPrompt = () => {
+      trackEvent('PwaInstallation', 'PWA installed')
       setShowInstallButton(false)
     }
 
@@ -63,7 +64,7 @@ const PwaInstallation = () => {
       )
       window.removeEventListener('appinstalled', handleAfterInstallPrompt)
     }
-  }, [hasChrome, hasSafari, isPWA])
+  }, [hasChrome, hasSafari, isPWA, trackEvent])
 
   const handleInstallClick = useCallback(() => {
     if (prompt) {

--- a/src/components/PwaInstallation.tsx
+++ b/src/components/PwaInstallation.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { CustomDimensions } from '@/components/Matomo/constants'
 import useMatomo from '@/components/Matomo/useMatomo'
 import { AddBoxOutlined, InstallMobile, IosShare } from '@mui/icons-material'
 import {
@@ -29,9 +30,12 @@ const PwaInstallation = () => {
   const hasChrome = browser.includes('Chrome')
   const hasSafari = browser.includes('Safari')
 
-  const { trackEvent } = useMatomo()
+  const { trackEvent, setCustomDimension } = useMatomo()
 
   useEffect(() => {
+    // set PWA state custom dimension
+    setCustomDimension(CustomDimensions.IS_PWA, isPWA ? 1 : 0)
+
     // this is needed because chrome on mac contains both strings
     if (!isPWA && !hasChrome && hasSafari) {
       // safari
@@ -64,7 +68,7 @@ const PwaInstallation = () => {
       )
       window.removeEventListener('appinstalled', handleAfterInstallPrompt)
     }
-  }, [hasChrome, hasSafari, isPWA, trackEvent])
+  }, [hasChrome, hasSafari, isPWA, setCustomDimension, trackEvent])
 
   const handleInstallClick = useCallback(() => {
     if (prompt) {


### PR DESCRIPTION
## Tickets
QA: https://raumobil.atlassian.net/browse/HDN-118?focusedCommentId=41896

* HDN-118: Tracking von "WebApp installieren"
  * HDN-133: Event direkt nach Installation tracken
  * HDN-134: custom dimension ob als PWA geöffnet oder nicht tracken

## Screenshots
<img width="1009" height="1046" alt="image" src="https://github.com/user-attachments/assets/99f7e1d9-47a9-4e47-ae17-aeb49482e98f" />
